### PR TITLE
Update to work with anime 3.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var anime = require('animejs');
+var anime = require('animejs').default;
 
 function install(Vue) {
   Vue.directive('anime', {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-animejs",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "A simple Vue plugin for binding Anime.js",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
### Description
This PR fixes current problem with vue-anime and animejs 3. I guess they've changed exports, so now it is required to import "default", otherwise you'll get an "anime is not a function" error.

![screen shot 2019-01-23 at 20 21 24](https://user-images.githubusercontent.com/10958990/51624765-989e5680-1f4c-11e9-9c8b-864403ce6aad.png)

### Possible drawbacks
I think it will stop working with old "anime" versions, so we need to release a "major" version.